### PR TITLE
Provide instructions to set up and run the MCP server without Docker

### DIFF
--- a/PYTHON_SETUP.md
+++ b/PYTHON_SETUP.md
@@ -1,0 +1,123 @@
+# Python Setup Guide for Redmine MCP Server
+
+## Quick Start (No Docker)
+
+### 1. Install Dependencies
+```bash
+pip install -r requirements.txt
+```
+
+### 2. Set Environment Variables
+```bash
+export REDMINE_URL="https://your-redmine-instance.com"
+export REDMINE_API_KEY="your-api-key-here"
+```
+
+### 3. Run the Server
+```bash
+# Simple FastMCP approach (recommended)
+python fastmcp_server.py
+
+# Or with configuration wrapper
+python mcp_config_example.py
+
+# Or complex implementation
+python src/mcp_server.py
+```
+
+## Configuration Options
+
+### Environment Variables
+- `REDMINE_URL` - Your Redmine instance URL (required)
+- `REDMINE_API_KEY` - Your Redmine API key (required)
+- `MCP_SERVER_MODE` - Server mode: live, debug, test (default: live)
+- `MCP_LOG_LEVEL` - Logging level: DEBUG, INFO, WARNING, ERROR (default: INFO)
+- `MCP_SERVER_TYPE` - Implementation: fastmcp, complex (default: fastmcp)
+
+### Python Integration Example
+```python
+import os
+from fastmcp_server import main
+import asyncio
+
+# Configure environment
+os.environ['REDMINE_URL'] = 'https://your-redmine.com'
+os.environ['REDMINE_API_KEY'] = 'your-key'
+
+# Run server
+asyncio.run(main())
+```
+
+## MCP Client Connection
+
+### Claude Desktop Configuration
+Add to your Claude Desktop config:
+```json
+{
+  "mcpServers": {
+    "redmine": {
+      "command": "python",
+      "args": ["/path/to/fastmcp_server.py"],
+      "env": {
+        "REDMINE_URL": "https://your-redmine.com",
+        "REDMINE_API_KEY": "your-api-key"
+      }
+    }
+  }
+}
+```
+
+### Direct Python Usage
+```python
+# Test server functionality
+from src.issues import IssueClient
+
+client = IssueClient(
+    base_url="https://your-redmine.com",
+    api_key="your-api-key"
+)
+
+# Test connection
+health = client.health_check()
+print(f"Connection: {'OK' if health else 'Failed'}")
+
+# Create an issue
+issue_data = {
+    "project_id": "project1",
+    "subject": "Test Issue",
+    "description": "Created via Python"
+}
+result = client.create_issue(issue_data)
+print(f"Created issue: {result['issue']['id']}")
+```
+
+## Available Tools
+
+- `redmine-create-issue` - Create new issues
+- `redmine-get-issue` - Get issue details
+- `redmine-list-issues` - List and filter issues
+- `redmine-update-issue` - Update existing issues
+- `redmine-delete-issue` - Delete issues
+- `redmine-health-check` - Check server connectivity
+- `redmine-get-current-user` - Get authenticated user info
+
+## Troubleshooting
+
+### Connection Issues
+```python
+# Test Redmine connectivity
+from src.issues import IssueClient
+client = IssueClient(url, api_key)
+if client.health_check():
+    print("Connection successful")
+else:
+    print("Check URL and API key")
+```
+
+### Container Environments
+For Jupyter, VS Code, or other container environments:
+```bash
+pip install nest_asyncio
+```
+
+The server automatically handles event loop conflicts in container environments.

--- a/mcp_config_example.py
+++ b/mcp_config_example.py
@@ -1,0 +1,174 @@
+#!/usr/bin/env python3
+"""
+Example configuration for running Redmine MCP Server directly with Python
+Demonstrates environment setup, client configuration, and server startup
+"""
+import os
+import sys
+import asyncio
+import logging
+from pathlib import Path
+
+# Add the current directory to Python path for imports
+project_root = Path(__file__).parent
+sys.path.insert(0, str(project_root))
+
+def setup_environment():
+    """Configure environment variables for Redmine MCP Server"""
+    
+    # Required Redmine configuration
+    os.environ['REDMINE_URL'] = 'https://your-redmine-instance.com'
+    os.environ['REDMINE_API_KEY'] = 'your-api-key-here'
+    
+    # Optional server configuration
+    os.environ['MCP_SERVER_MODE'] = 'live'  # Options: live, debug, test
+    os.environ['MCP_LOG_LEVEL'] = 'INFO'    # Options: DEBUG, INFO, WARNING, ERROR
+    
+    # Optional Redmine connection settings
+    os.environ['REDMINE_TIMEOUT'] = '30'
+    os.environ['REDMINE_MAX_RETRIES'] = '3'
+    
+    print("Environment configured for Redmine MCP Server")
+
+def validate_configuration():
+    """Validate that required configuration is present"""
+    required_vars = ['REDMINE_URL', 'REDMINE_API_KEY']
+    missing_vars = [var for var in required_vars if not os.getenv(var)]
+    
+    if missing_vars:
+        print(f"Error: Missing required environment variables: {', '.join(missing_vars)}")
+        print("\nPlease set the following:")
+        for var in missing_vars:
+            if var == 'REDMINE_URL':
+                print(f"  {var}=https://your-redmine-instance.com")
+            elif var == 'REDMINE_API_KEY':
+                print(f"  {var}=your-api-key-here")
+        return False
+    
+    print("Configuration validation passed")
+    return True
+
+async def run_fastmcp_server():
+    """Run the FastMCP server (recommended approach)"""
+    try:
+        from fastmcp_server import main
+        print("Starting FastMCP server...")
+        await main()
+    except ImportError:
+        print("Error: fastmcp_server.py not found")
+        print("Using fallback to complex server...")
+        await run_complex_server()
+
+async def run_complex_server():
+    """Run the complex server implementation"""
+    try:
+        from src.mcp_server import RedmineMCPServer
+        
+        server = RedmineMCPServer()
+        server.initialize()
+        
+        print("Starting Redmine MCP Server...")
+        await server.run()
+        
+    except Exception as e:
+        print(f"Server startup failed: {e}")
+        raise
+
+def setup_logging():
+    """Configure logging for the MCP server"""
+    log_level = os.getenv('MCP_LOG_LEVEL', 'INFO').upper()
+    
+    logging.basicConfig(
+        level=getattr(logging, log_level),
+        format='%(asctime)s - %(name)s - %(levelname)s - %(message)s',
+        handlers=[
+            logging.StreamHandler(sys.stdout),
+            logging.FileHandler('mcp_server.log')
+        ]
+    )
+    
+    print(f"Logging configured at {log_level} level")
+
+async def main():
+    """Main entry point for Python MCP server"""
+    print("=== Redmine MCP Server Configuration ===")
+    
+    # Step 1: Setup environment
+    setup_environment()
+    
+    # Step 2: Setup logging
+    setup_logging()
+    
+    # Step 3: Validate configuration
+    if not validate_configuration():
+        sys.exit(1)
+    
+    # Step 4: Choose server implementation
+    server_choice = os.getenv('MCP_SERVER_TYPE', 'fastmcp').lower()
+    
+    if server_choice == 'fastmcp':
+        print("Using FastMCP implementation (recommended)")
+        await run_fastmcp_server()
+    else:
+        print("Using complex server implementation")
+        await run_complex_server()
+
+def run_with_container_compatibility():
+    """Run server with container environment compatibility"""
+    try:
+        # Check if there's already a running event loop
+        loop = asyncio.get_running_loop()
+        print("Detected existing event loop - using container compatibility mode")
+        
+        # Import nest_asyncio for nested loop support
+        try:
+            import nest_asyncio
+            nest_asyncio.apply()
+            task = loop.create_task(main())
+            return task
+        except ImportError:
+            print("Installing nest_asyncio for container compatibility...")
+            import subprocess
+            subprocess.check_call([sys.executable, "-m", "pip", "install", "nest_asyncio"])
+            import nest_asyncio
+            nest_asyncio.apply()
+            task = loop.create_task(main())
+            return task
+            
+    except RuntimeError:
+        # No event loop running, we can start our own
+        print("Starting new event loop for MCP server")
+        return asyncio.run(main())
+
+if __name__ == "__main__":
+    print("""
+=== Redmine MCP Server Python Configuration ===
+
+Before running, please set your environment variables:
+
+export REDMINE_URL="https://your-redmine-instance.com"
+export REDMINE_API_KEY="your-api-key-here"
+
+Optional settings:
+export MCP_SERVER_MODE="live"          # live, debug, test
+export MCP_LOG_LEVEL="INFO"            # DEBUG, INFO, WARNING, ERROR
+export MCP_SERVER_TYPE="fastmcp"       # fastmcp, complex
+
+Then run:
+python mcp_config_example.py
+
+Or use the configuration programmatically in your own script.
+    """)
+    
+    # Check if environment is configured
+    if not os.getenv('REDMINE_URL') or not os.getenv('REDMINE_API_KEY'):
+        print("Please configure environment variables before running.")
+        sys.exit(1)
+    
+    try:
+        run_with_container_compatibility()
+    except KeyboardInterrupt:
+        print("\nServer stopped by user")
+    except Exception as e:
+        print(f"Server error: {e}")
+        sys.exit(1)


### PR DESCRIPTION
Adds PYTHON_SETUP.md guide and mcp_config_example.py for Python-based Redmine MCP server setup, including env vars and direct execution.

Replit-Commit-Author: Agent
Replit-Commit-Session-Id: 5c34e02a-1712-4e3a-bea0-c2204d98b09c
Replit-Commit-Screenshot-Url: https://storage.googleapis.com/screenshot-production-us-central1/20275c91-1083-40af-8866-dd6c147b71d0/d3c2e7cc-ccfb-4ad7-92ba-7aa137e20100.jpg